### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,4 +1,6 @@
 name: Version Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/recal-dev/scheduling-sdk/security/code-scanning/3](https://github.com/recal-dev/scheduling-sdk/security/code-scanning/3)

To address the flagged issue, we should set the `permissions` key in the workflow to limit the actions jobs' GITHUB_TOKEN privileges to the minimum necessary. In this workflow, the actions (`actions/checkout`, reading package version, running npm view, etc.) only require reading repository contents – no write operations are performed.  
**Steps:**  
- Add a `permissions` block at the root of `.github/workflows/version-check.yml` (just below the `name:` line, before `on:`).  
- Set the minimal permission required: `contents: read`.  
- No additional imports or code changes are necessary, as this is a workflow-level policy declaration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
